### PR TITLE
Remove GitHub Copilot from pyproject.toml authors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "diffwhisperer"
 version = "1.0.0"
 description = "An AI agent for generating meaningful git commit messages using Google's Gemini AI"
 authors = [
-    {name = "GitHub Copilot"}
+    {name = "Meher Bhaskar"}
 ]
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
The GitHub Copilot entry was mistakenly added to the pyproject.toml file. This commit removes the incorrect author entry to ensure accurate project metadata.

This change clarifies the project's intended authorship and avoids any potential misrepresentation regarding contributions. No functional changes are introduced.